### PR TITLE
Removing the Key of Eternity as Win Req.

### DIFF
--- a/src/main/resources/lmr/randomizer/requirement/win_reqs.txt
+++ b/src/main/resources/lmr/randomizer/requirement/win_reqs.txt
@@ -1,6 +1,5 @@
 Holy Grail
 Feather
-Key of Eternity
 Origin Seal
 Birth Seal
 Life Seal


### PR DESCRIPTION
With EC randomized, the key is not always necessary.