### PR TITLE
Widen automatic grail tablet registration box

### DIFF
--- a/src/main/java/lmr/randomizer/dat/AddObject.java
+++ b/src/main/java/lmr/randomizer/dat/AddObject.java
@@ -2635,14 +2635,14 @@ public final class AddObject {
     public static void addGrailDetector(GameObject gameObject, int grailFlag) {
         GameObject grailDetector = new GameObject(gameObject.getObjectContainer());
         grailDetector.setId((short)0x14);
-        grailDetector.setX(gameObject.getX());
+        grailDetector.setX(gameObject.getX() - 20);
         grailDetector.setY(gameObject.getY() - 20);
 
         grailDetector.getArgs().add((short)0); // seconds wait
         grailDetector.getArgs().add((short)0); // frames wait
         grailDetector.getArgs().add((short)0); // continuous/total
         grailDetector.getArgs().add((short)0); // interaction type 0 = any time except paused 1 = 2 = 3 = 4 = just be on the ground, ok. default: sleep
-        grailDetector.getArgs().add((short)2); // graphical tile width
+        grailDetector.getArgs().add((short)4); // graphical tile width
         grailDetector.getArgs().add((short)3); // graphical tile height
 
         TestByteOperation testByteOperation = new TestByteOperation();


### PR DESCRIPTION
0xb6 save points test x < lemeza_x + 20 < x + 40
0x14 detectors effectively test x + 10 < lemeza_x + 20 <= x + w*20 - 10
Moving the detector 10 pixels left and increasing the width to 60 would be precisely right except for the last subpixel on the right, but we're limited to multiples of 20 so I had to make it 80 wide.