### PR TITLE
Fix Boss Checkpoint Settings Import Bug

### DIFF
--- a/src/main/java/lmr/randomizer/ui/ConveniencePanel.java
+++ b/src/main/java/lmr/randomizer/ui/ConveniencePanel.java
@@ -57,5 +57,6 @@ public class ConveniencePanel extends JPanel {
         automaticGrailPoints.setSelected(Settings.isAutomaticGrailPoints());
         automaticTranslations.setSelected(Settings.isAutomaticTranslations());
         ushumgalluAssist.setSelected(Settings.isUshumgalluAssist());
+        bossCheckpoints.setSelected(Settings.isBossCheckpoints());
     }
 }


### PR DESCRIPTION
The reloadSettings method was missing the code needed for setting the bossCheckpoints checkbox on import