### PR TITLE
Small fixes: seal removal and platform neutral jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,12 +24,6 @@
             <artifactId>miglayout-swing</artifactId>
             <version>5.2</version>
         </dependency>
-
-        <dependency>
-            <groupId>org.openjfx</groupId>
-            <artifactId>javafx-controls</artifactId>
-            <version>11</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/lmr/randomizer/DataFromFile.java
+++ b/src/main/java/lmr/randomizer/DataFromFile.java
@@ -334,6 +334,9 @@ public final class DataFromFile {
                         || "Isis' Pendant".equals(itemName)) {
                     continue; // Things that should never be removed.
                 }
+                if(!Settings.isRandomizeSeals() && itemName.endsWith(" Seal")) {
+                    continue;
+                }
                 if(!Settings.isFeatherlessMode() && "Feather".equals(itemName)) {
                     continue;
                 }


### PR DESCRIPTION
JavaFX was only used for pair and excluding seals from potential removed items when seal shuffle is off should reduce required attempts on average.