### PR TITLE
Add checks for Steam Linux install locations

### DIFF
--- a/src/main/java/lmr/randomizer/Settings.java
+++ b/src/main/java/lmr/randomizer/Settings.java
@@ -156,11 +156,26 @@ public final class Settings {
         minRandomRemovedItems = 0;
         maxRandomRemovedItems = 0;
 
+        // Check for Linux Steam installs. The "HOME" environment variable typically only exists on Linux and returns "/home/[user]".
+        // If requested on Windows it'll return null, hence the null check.
+        // The Linux GOG check could possibly be moved up here as well.
+        // Added by Nat the Chicken, March 2023.
+        String linuxUserPath = System.getenv("HOME");
+        if (linuxUserPath != null) {
+            for (String filename : Arrays.asList(linuxUserPath + "/.steam/debian-installation/steamapps/common/La-Mulana", //the usual location
+                    linuxUserPath + "/.steam/root/steamapps/common/La-Mulana", //this is usually a symlink to the real install and serves as a catch-all
+                    linuxUserPath + "/.local/share/Steam/steamapps/common/La-Mulana")) { //just in case they have an ANCIENT installation
+                if (new File(filename).exists()) {
+                    laMulanaBaseDir = filename;
+                    break;
+                }
+            }
+        }
+
         for (String filename : Arrays.asList("C:\\Games\\La-Mulana Remake 1.3.3.1", "C:\\GOG Games\\La-Mulana", "C:\\GOG Games\\La-Mulana",
                 "C:\\Steam\\steamapps\\common\\La-Mulana", "C:\\Program Files (x86)\\Steam\\steamapps\\common\\La-Mulana",
                 "C:\\Program Files\\Steam\\steamapps\\common\\La-Mulana", "C:\\Program Files (x86)\\GOG Galaxy\\Games\\La Mulana",
-                "C:\\Program Files (x86)\\GOG.com\\La-Mulana"
-                /* Steam on Linux path? */)) {
+                "C:\\Program Files (x86)\\GOG.com\\La-Mulana")) {
             if (new File(filename).exists()) {
                 laMulanaBaseDir = filename;
                 break;

--- a/src/main/java/lmr/randomizer/Settings.java
+++ b/src/main/java/lmr/randomizer/Settings.java
@@ -162,11 +162,11 @@ public final class Settings {
         // Added by Nat the Chicken, March 2023.
         String linuxUserPath = System.getenv("HOME");
         if (linuxUserPath != null) {
-            for (String filename : Arrays.asList(linuxUserPath + "/.steam/debian-installation/steamapps/common/La-Mulana", //the usual location
-                    linuxUserPath + "/.steam/root/steamapps/common/La-Mulana", //this is usually a symlink to the real install and serves as a catch-all
-                    linuxUserPath + "/.local/share/Steam/steamapps/common/La-Mulana")) { //just in case they have an ANCIENT installation
-                if (new File(filename).exists()) {
-                    laMulanaBaseDir = filename;
+            for (String filename : Arrays.asList("/.steam/debian-installation/steamapps/common/La-Mulana", //the usual location
+                    "/.steam/root/steamapps/common/La-Mulana", //this is usually a symlink to the real install and serves as a catch-all
+                    "/.local/share/Steam/steamapps/common/La-Mulana")) { //just in case they have an ANCIENT installation
+                if (new File(linuxUserPath + filename).exists()) {
+                    laMulanaBaseDir = linuxUserPath + filename;
                     break;
                 }
             }


### PR DESCRIPTION
Added checks for a few common locations where Steam might install the game on Linux, checking a Linux-specific environment variable to get the user directory. When tested, it was able to find the game when it was installed at the first listed location.
I noticed this code comment when I was hunting through the files figuring them out, and it seemed like the perfect thing for me to add, since I run the game and randomizer entirely on Ubuntu with Proton. (Also, it's purely for QoL during first setup, and won't break if the user's file tree is in some bizarre configuration.) As a possible next step, this section of Settings.java could also be modified to check common save data locations, including locations used by Proton as well as Windows and Linux builds running natively, and determine which location is in use by whether it contains a lamu.dat file.

I had plans for bigger contributions, especially to do with seed export/import, but I've been told to "start small," and also I'm not very good at using git yet. So I'm not going to overhaul anything right now, and if I do, it may end up confined to my own fork.