### PR TITLE
Fix "Remove Logic"

### DIFF
--- a/src/main/java/lmr/randomizer/FileUtils.java
+++ b/src/main/java/lmr/randomizer/FileUtils.java
@@ -421,7 +421,7 @@ public class FileUtils {
                             customPlacementData.getRemovedItems().add(removeItem.substring(1).trim());
                         }
                     }
-                    else if (line.startsWith("Remove")) {
+                    else if (line.startsWith("Remove") && !line.startsWith("Remove Logic:")) {
                         customPlacementData.setCustomized(true);
                         customPlacementData.getRemovedItems().add(line.replace("Remove", "").trim());
                     }


### PR DESCRIPTION
The "Remove Logic" command currently does not work in custom placement files because it's overridden by the "Remove" command.

This fix is currently untested (the "Remove Logic" command may also be untested).